### PR TITLE
Set up MapIt in the dev VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,14 @@ RESTful API for looking up postcodes, council boundaries, etc.
 MapIt has no dependencies on the rest of the GOV.UK stack, but does use PostgreSQL
 with some geo-spatial extensions. For the GOV.UK VM these are documented in [puppet](https://github.gds/gds/puppet/blob/master/modules/govuk/manifests/apps/mapit.pp), or you can follow the [standalone install guide](http://mapit.poplus.org/docs/self-hosted/install/).
 
-### Running the application
+### Running the application in development
 
-You'll need to be in a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/), and install dependencies with:
+Run this application with Bowler: `bowl mapit`.
 
-```pip install -r requirements.txt```
+Or use the startup script directly: `GOVUK_ENV=development ./startup.sh`.
 
-You can then run an instance of mapit with:
-
-```manage.py runserver 127.0.0.1:3108```
+To run any other management commands (`./manage.py ...`), you'll need the
+`GOVUK_ENV` environment variable set.
 
 ## Licence
 

--- a/conf/development.yml
+++ b/conf/development.yml
@@ -1,0 +1,59 @@
+# general.yml-example:
+# Example values for the "general.yml" config file.
+#
+# Copy this file to one called "general.yml" in the same directory. Or have
+# multiple config files and use a symlink to change between them.
+
+# Connection details for database
+MAPIT_DB_NAME: 'mapit'
+MAPIT_DB_USER: 'mapit'
+MAPIT_DB_PASS: 'mapit'
+MAPIT_DB_HOST: 'localhost'
+MAPIT_DB_PORT: null
+
+# Country is currently one of GB, NO, or KE. Optional; country specific things won't happen if not set.
+COUNTRY: 'GB'
+
+# An EPSG code for what the areas are stored as, e.g. 27700 is OSGB, 4326 for WGS84.
+# Optional, defaults to 4326.
+AREA_SRID: 27700
+
+# A secret key for this particular Django installation.
+# Set this to a random string -- the longer, the better.
+DJANGO_SECRET_KEY: 'gu^&xc)hoibh3x&s+9009jbn4d$!nq0lz+syx-^x8%z24!kfs4'
+
+# Mapped to Django's DEBUG and TEMPLATE_DEBUG settings. Optional, defaults to True.
+DEBUG: True
+
+# A GA code
+GOOGLE_ANALYTICS: ""
+
+# A list of IP addresses or User Agents that should be excluded from rate limiting. Optional.
+RATE_LIMIT:
+  - '127.0.0.1'
+
+# Email address that errors should be sent to. Optional.
+BUGS_EMAIL: 'example@example.org'
+
+#########################################################################
+
+# You can ignore all of the settings below this point in the file
+# unless you want to use the scripts for setting up MapIt Global.
+
+# The scripts for setting up global MapIt rely on a Overpass API
+# server.  For bulk imports (e.g. setting up a instance of Global
+# MapIt) you should set up your own Overpass server locally, but for
+# generating a few KML files from OSM, it's easier to just use a
+# remote server.
+LOCAL_OVERPASS: False
+
+# If you want to use a local overpass server (i.e. LOCAL_OVERPASS is
+# True) then you should specify here the path to the database
+# directory.
+OVERPASS_DB_DIRECTORY: '/home/overpass/db/'
+
+# If you're using a remote overpass server (i.e. LOCAL_OVERPASS is
+# False) you should set its URL here. Please be aware that these
+# scripts can put a lot of load on the remote server, so set up your
+# own Overpass server for bulk imports.
+OVERPASS_SERVER: 'http://overpass-api.de/api/interpreter'

--- a/project/settings.py
+++ b/project/settings.py
@@ -14,8 +14,14 @@ PARENT_DIR = os.path.dirname(BASE_DIR)
 # of the repo, containing a general.yml file of options. Use that file if
 # present. Obviously you can just edit any part of this file, it is a normal
 # Django settings.py file.
+ENVIRONMENT = os.environ.get('GOVUK_ENV', 'production')
+if ENVIRONMENT == 'development':
+    conffile = 'development.yml'
+else:
+    conffile = 'general.yml'
+
 try:
-    with open(os.path.join(BASE_DIR, 'conf', 'general.yml'), 'r') as fp:
+    with open(os.path.join(BASE_DIR, 'conf', conffile), 'r') as fp:
         config = yaml.load(fp)
 except:
     config = {}

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+DIRECTORY='.venv'
+if [ ! -d "$DIRECTORY" ]; then
+  virtualenv --no-site-packages "$DIRECTORY"
+fi
+
+$DIRECTORY/bin/pip install -qr requirements.txt
+$DIRECTORY/bin/python ./manage.py migrate -v 0
+$DIRECTORY/bin/python ./manage.py runserver 3108


### PR DESCRIPTION
- Add the ability to run this app in the dev VM using `bowl mapit` and a `startup.sh` script like a lot of our other apps.
- Trello: https://trello.com/c/oC8pIyEc/164-set-up-mapit-to-run-in-the-dev-vm.

(Paired with @jennyd on this. Related to https://github.gds/gds/puppet/pull/3614)