### PR TITLE
Add script for importing a new db from the S3 dump

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# get the data from s3
+curl 'https://gds-public-readable-tarballs.s3.amazonaws.com/mapit-postgres93-Jan2016.sql.gz' -o mapit.sql.gz
+if ! echo "1120be001e65283a1a1c50d73f93ddd093f91c17 mapit.sql.gz" | sha1sum -c -; then
+  echo "SHA1 does not match downloaded file!"
+  exit 1
+fi
+
+# drop the old db and bring up a new empty one
+sudo -u postgres dropdb --if-exists mapit
+sudo -u postgres createdb --owner mapit mapit
+sudo -u postgres psql -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
+
+# load up the downloaded data into this new db
+zcat -f mapit.sql.gz | sudo -u postgres psql mapit


### PR DESCRIPTION
On the old mapit servers we did this via a combination of a fabric script and puppet.  Puppet downloaded the dump and loaded it into the DB, fabric wiped the old db and then ran puppet.  We'll still need a fabric script to orchestrate running this script on servers (and to bounce the app / nginx to pick up the new db and data).  We moved to an app-local script because:

1. loading data via puppet is not something that other govuk-puppet-managed-apps do.
2. it breaks the requirement on deploying puppet if we want to load a new data set into deployed environments.  Note that instead we have a requirement on deploying the app itself because the url and sha are part of the script; they could be arguments but we wanted a git-based audit trail of when the dataset is updated.
3. it gives us a loading script that will work on the dev vm allowing us to load the data for development.

Note that the dataset and sha referenced are made up of the ONSPD August 2015 dataset, Boundary Line November 2015 dataset, and the NI shape data from November 2015.  See: https://github.gds/gds/mapit-scripts/pull/2, https://github.com/alphagov/mapit/pull/7 and https://trello.com/c/a7c1LPbl/26-get-mapit-database-onto-new-preview-machine for more context on this import process and data.