### PR TITLE
Download the S3 db dump as the deploy user

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -2,7 +2,7 @@
 set -e
 
 # get the data from s3
-curl 'https://gds-public-readable-tarballs.s3.amazonaws.com/mapit-postgres93-Jan2016.sql.gz' -o mapit.sql.gz
+sudo -u deploy curl 'https://gds-public-readable-tarballs.s3.amazonaws.com/mapit-postgres93-Jan2016.sql.gz' -o mapit.sql.gz
 if ! echo "1120be001e65283a1a1c50d73f93ddd093f91c17 mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1


### PR DESCRIPTION
The script is intended to be run as a user that can passwordless sudo so
they can become postgres and run the pg commands to create the db, install
the extensions, and import the db dump.  However, this user won't have
write permissions on the app directory so the download will fail.  Happily
they can also passwordless sudo to deploy who will have write permissions.

We don't need the sudo on reading the file as our non-sudo user will have
read permissions.

This is to enable https://github.com/alphagov/fabric-scripts/pull/191 to run correctly on our deployed environments.