### PR TITLE
Run app with unicornherder from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./venv/bin/gunicorn project.wsgi:application --bind 127.0.0.1:3108 --workers 8
+web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/mapit/app.pid  -- project.wsgi:application --bind 127.0.0.1:3108 --workers 8


### PR DESCRIPTION
Running the app with [unicornherder](https://github.com/gds-operations/unicornherder) gives us zero-downtime deploys. The `rack`
app type in govuk_puppet uses unicornherder, but the [one we're using](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/mapit.pp#L21)
(`procfile`) doesn't - it just uses the command given in the Procfile to run
the app - see the govuk_spinup script [1]. Putting the unicornherder command
in the app's Procfile lets us use the globally-installed unicornherder
version (which keeps it more consistent with other apps) while running the app
with the virtualenv-installed gunicorn version.

The `rack` app type has configuration which is specific to unicorn, so it
won't work as-is with a Python WSGI app and gunicorn. It also enables some
monitoring which isn't enabled for the `procfile` type [2]. It would be
preferable to have an app type which works with WSGI and gunicorn but
otherwise provides the same functionality as `rack`, but we'd like to see this
command working from the Procfile before trying to make that larger Puppet
change.

I've tested this command in my dev VM and unicornherder works fine: when I
send HUP to unicornherder it correctly forks a new gunicorn master and kills
the old one after 2 minutes. (I had to manually create `/var/run/mapit` and
chown it to `vagrant` to allow the pidfile to be created, but that directory
already exists on the Integration machine so should work fine there.)

[1]: https://github.com/alphagov/govuk-puppet/blob/78a074980f2fb042965a3ec757c7d08e1981e846/modules/govuk/files/usr/local/bin/govuk_spinup
[2]: https://github.com/alphagov/govuk-puppet/blob/ed72895c0ab419424cae631f367dc3f709089243/modules/govuk/manifests/app/config.pp#L198-L225