### PR TITLE
Add GSS code in the ONS code field for all NI councils

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -38,6 +38,8 @@ class Command(NoArgsCommand):
             MissingOnsCode(code='26UD', area_type='DIS', area_name='East Hertfordshire District Council'),
             MissingOnsCode(code='26UH', area_type='DIS', area_name='Stevenage Borough Council'),
             MissingOnsCode(code='00CH', area_type='MTD', area_name='Gateshead Borough Council'),
+            # Adding GSS Code as an Ons code to try to support NI areas
+            MissingOnsCode(code='N09000011', area_type='LGD', area_name='Ards and North Down Borough Council'),
         ]
 
 

--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -39,9 +39,18 @@ class Command(NoArgsCommand):
             MissingOnsCode(code='26UH', area_type='DIS', area_name='Stevenage Borough Council'),
             MissingOnsCode(code='00CH', area_type='MTD', area_name='Gateshead Borough Council'),
             # Adding GSS Code as an Ons code to try to support NI areas
+            MissingOnsCode(code='N09000001', area_type='LGD', area_name='Antrim and Newtownabbey Borough Council'),
+            MissingOnsCode(code='N09000002', area_type='LGD', area_name='Armagh City, Banbridge and Craigavon Borough Council'),
+            MissingOnsCode(code='N09000003', area_type='LGD', area_name='Belfast City Council'),
+            MissingOnsCode(code='N09000004', area_type='LGD', area_name='Causeway Coast and Glens Borough Council'),
+            MissingOnsCode(code='N09000005', area_type='LGD', area_name='Derry City and Strabane District Council'),
+            MissingOnsCode(code='N09000006', area_type='LGD', area_name='Fermanagh and Omagh District Council'),
+            MissingOnsCode(code='N09000007', area_type='LGD', area_name='Lisburn and Castlereagh City Council'),
+            MissingOnsCode(code='N09000008', area_type='LGD', area_name='Mid and East Antrim Borough Council'),
+            MissingOnsCode(code='N09000009', area_type='LGD', area_name='Mid Ulster District Council'),
+            MissingOnsCode(code='N09000010', area_type='LGD', area_name='Newry, Mourne and Down District Council'),
             MissingOnsCode(code='N09000011', area_type='LGD', area_name='Ards and North Down Borough Council'),
         ]
-
 
 class MissingCode(object):
     def __init__(self, code, area_type, area_name):


### PR DESCRIPTION
Northern Irish authorities don't have ONS (aka SNAC) codes as the boundaries were reorganised after the demise of the code format.  This means that some of our services don't work well with NI, as we're heavily reliant on ONS codes at present.

As a stopgap until we move all of GOV.UK over to using GSS codes, we will put the GSS code into the the empty ONS code field for all NI councils.

https://trello.com/c/kjurG3i8/302-support-new-northern-ireland-local-authorities-for-licensing