### PR TITLE
Set environment specific email subject

### DIFF
--- a/conf/development.yml
+++ b/conf/development.yml
@@ -32,8 +32,11 @@ GOOGLE_ANALYTICS: ""
 RATE_LIMIT:
   - '127.0.0.1'
 
-# Email address that errors should be sent to. Optional.
+# Email address that errors should be sent to. Optional. Only used if DEBUG=False
 BUGS_EMAIL: 'example@example.org'
+
+# Overrides the default subject prefix of '[Django] '
+# EMAIL_SUBJECT_PREFIX: '[MapIt Dev] '
 
 #########################################################################
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -78,6 +78,9 @@ if config.get('BUGS_EMAIL'):
         ('mySociety bugs', config['BUGS_EMAIL']),
     )
 
+if config.get('EMAIL_SUBJECT_PREFIX'):
+    EMAIL_SUBJECT_PREFIX = config['EMAIL_SUBJECT_PREFIX']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',


### PR DESCRIPTION
The default email subject prefix for MapIt exception emails is '[Django] ' (the default in Django) which is not useful.  This enables setting of environment specific overrides.  The corresponding overrides
for the various environments are set in alphagov-deployment, but will fall back to the default.

The two PRs can be deployed independently.

Alphagov-deployment PR:
https://github.gds/gds/alphagov-deployment/pull/1167