### PR TITLE
Upgrade Django to 1.8.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.3
+Django==1.8.12
 PyYAML==3.11
 Shapely==1.5.9
 argparse==1.2.1


### PR DESCRIPTION
We previously upgraded to 1.8.9 in a PR [1] which was merged into a branch
which was for another PR [2]. However that upgrade commit seems to have been
lost from the other PR before it was merged, so we're still on 1.8.3.

1.8.12 is the latest 1.8.x version, and includes some bugfixes and security
fixes since 1.8.3.

[1]: https://github.com/alphagov/mapit/pull/11
[2]: https://github.com/alphagov/mapit/pull/7