### PR TITLE
Fix index out of range error for fix-2016-05 script

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_fix_2016-05.py
+++ b/mapit_gb/management/commands/mapit_UK_fix_2016-05.py
@@ -21,7 +21,7 @@ class Command(NoArgsCommand):
 
     def get_generation_prior_to_current(self):
         latest_on = Generation.objects.filter(active=True).order_by('-id')
-        if latest_on:
+        if latest_on and len(latest_on) > 1:
             return latest_on[1]
         return None
 


### PR DESCRIPTION
When getting the previous generation, the code was selecting the second element from the array. In the case of only having one Generation (as in our case when we drop the database before a new import), this will cause a `IndexError: list index out of range` error. The code change ensures that we have at least 2 elements in the array before picking the second element.

This might be worth pushing upstream to MySociety's MapIt?