### PR TITLE
Update 'add_ons_to_gss' command to support CSVReader for Python 2

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -40,7 +40,8 @@ class Command(NoArgsCommand):
             MissingOnsCode(code='00CH', area_type='MTD', area_name='Gateshead Borough Council'),
             # Adding GSS Code as an Ons code to try to support NI areas
             MissingOnsCode(code='N09000001', area_type='LGD', area_name='Antrim and Newtownabbey Borough Council'),
-            MissingOnsCode(code='N09000002', area_type='LGD', area_name='Armagh City, Banbridge and Craigavon Borough Council'),
+            MissingOnsCode(code='N09000002', area_type='LGD',
+                           area_name='Armagh City, Banbridge and Craigavon Borough Council'),
             MissingOnsCode(code='N09000003', area_type='LGD', area_name='Belfast City Council'),
             MissingOnsCode(code='N09000004', area_type='LGD', area_name='Causeway Coast and Glens Borough Council'),
             MissingOnsCode(code='N09000005', area_type='LGD', area_name='Derry City and Strabane District Council'),
@@ -51,6 +52,7 @@ class Command(NoArgsCommand):
             MissingOnsCode(code='N09000010', area_type='LGD', area_name='Newry, Mourne and Down District Council'),
             MissingOnsCode(code='N09000011', area_type='LGD', area_name='Ards and North Down Borough Council'),
         ]
+
 
 class MissingCode(object):
     def __init__(self, code, area_type, area_name):

--- a/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
+++ b/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
@@ -4,6 +4,7 @@
 import codecs
 import csv
 import os.path
+import sys
 from django.core.management.base import NoArgsCommand
 from mapit.models import Area, CodeType
 from psycopg2 import IntegrityError
@@ -30,22 +31,30 @@ class Command(NoArgsCommand):
     help = 'Inserts the old ONS codes into mapit'
 
     def handle_noargs(self, **options):
-        code_changes = codecs.open(os.path.join(
+        python_version = sys.version_info[0]
+
+        code_change_file_path = os.path.join(
             os.path.dirname(__file__),
-            '../../data/BL-2010-10-code-change.csv'
-            ), 'r', 'latin-1')
-        mapping = csv.reader(code_changes)
+            '../../data/BL-2010-10-code-change.csv')
+        if python_version < 3:
+            mapping = csv.reader(open(code_change_file_path))
+        else:
+            code_changes = codecs.open(code_change_file_path, 'r', 'latin-1')
+            mapping = csv.reader(code_changes)
         next(mapping)
         for row in mapping:
-            new_code, name, old_code = row[0], row[1], row[3]
+            new_code, old_code = row[0], row[3]
             process(new_code, old_code)
 
-        missing_codes = codecs.open(os.path.join(
+        missing_codes_file_path = os.path.join(
             os.path.dirname(__file__),
-            '../../data/BL-2010-10-missing-codes.csv'
-            ), 'r', 'latin-1')
-        mapping = csv.reader(missing_codes)
+            '../../data/BL-2010-10-missing-codes.csv')
+        if python_version < 3:
+            mapping = csv.reader(open(missing_codes_file_path))
+        else:
+            missing_codes = codecs.open(missing_codes_file_path, 'r', 'latin-1')
+            mapping = csv.reader(missing_codes)
         next(mapping)
         for row in mapping:
-            type, new_code, old_code, name = row
+            new_code, old_code = row[1], row[2]
             process(new_code, old_code)

--- a/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py
+++ b/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py
@@ -31,6 +31,6 @@ class Command(NoArgsCommand):
                 except Area.DoesNotExist:
                     # An area that existed at the time of the mapping, but no longer
                     print 'Area for {authority} {gss_code} not found'.format(
-                        authority=authority,
+                        authority=slug,
                         gss_code=gss_code
                     )

--- a/mapit_gb/management/commands/mapit_UK_show_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_show_missing_codes.py
@@ -46,7 +46,8 @@ class Command(NoArgsCommand):
                 type=area_type
             )
             for code_type in used_code_types:
-                if self.is_code_type_not_required_for_area_type(code_type, area_type): continue
+                if self.is_code_type_not_required_for_area_type(code_type, area_type):
+                    continue
 
                 areas_without_codes = areas.exclude(codes__type__code=code_type)
                 if areas_without_codes.count() > 0:


### PR DESCRIPTION
The command would error when running with Python 2.7, failing to recognise the Welsh characters `ô` and `â` with "UnicodeEncodeError: 'ascii' codec can't encode character u'\xf4' in position 16: ordinal not in range(128)". This is due to `csv.reader` changing between Python 2 and 3 - in 2 it expected a file-like object on which next() would return raw bytes, and in 3 one which would return unicode strings (found by @jennyd). We opt to explicitly check which version of Python is running and run the old code for < Python 3.

We fix some flake8 style violations for mapit_gb scripts as well.

See https://github.com/alphagov/mapit/pull/23 for more details