### PR TITLE
Upgrade Django to 1.8.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.12
+Django==1.8.14
 PyYAML==3.11
 Shapely==1.5.9
 argparse==1.2.1


### PR DESCRIPTION
This is a [security release](https://docs.djangoproject.com/en/1.9/releases/1.8.14/) for a XSS vulnerability in the admin interface. We
don't expose our MapIt externally and don't have any users for the admin
interface so shouldn't be affected by it, but should upgrade anyway. [1.8.13](https://docs.djangoproject.com/en/1.9/releases/1.8.13/)
was a bugfix release.