### PR TITLE
Add DIS->CTY to the find parents command

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -2,8 +2,8 @@
 set -e
 
 # get the data from s3
-sudo -u deploy curl 'https://s3.amazonaws.com/gds-public-readable-tarballs/mapit-postgres93-May2016.sql.gz' -o mapit.sql.gz
-if ! echo "15d7e1eab81476511b96d773762ef6268d3d4289 mapit.sql.gz" | sha1sum -c -; then
+sudo -u deploy curl 'https://s3.amazonaws.com/gds-public-readable-tarballs/mapit-postgres93-May2016-dis-cty-hierarchy.sql.gz' -o mapit.sql.gz
+if ! echo "40f9c917719dc83cb5f24c86b9ee6da613e89a7b  mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1
 fi

--- a/mapit_gb/management/commands/mapit_UK_find_parents.py
+++ b/mapit_gb/management/commands/mapit_UK_find_parents.py
@@ -10,6 +10,8 @@ class Command(FindParentsCommand):
     parentmap = {
         # A District council ward's parent is a District council:
         'DIW': 'DIS',
+        # A District council's parent is a County council:
+        'DIS': 'CTY',
         # A County council ward's parent is a County council:
         'CED': 'CTY',
         # A London borough ward's parent is a London borough:


### PR DESCRIPTION
District councils are all children of a county council, much like district
wards are children of a district council or county wards are children of a
county council.

One approach would be to write a script to explicitly connect all DIS
areas to the coorect CTY area, much like the old NI import scripts did
before we had boundary data (see:
mapit_gb/management/commands/mapit_UK_import_nspd_ni_areas.py and the
fixture mapit_gb/data/ni-electoral-areas.csv).

One downside to this is having to create a fixture of all the districts
and their correct county, which we'd need to update as boundaries change
and new councils are created or merged.  However, we know that (for now at
least) all districts live within a county so we can use geographic point
lookups to ask which CTY areas contain each DIS area.  The existing
mapit_UK_find_parents command already does this for other area types so
we just add DIS->CTY to the list of area types that it will consider.

For: https://trello.com/c/XJ4pDHxG/433-1-of-3-add-parent-child-relationships-to-mapit-3