### PR TITLE
Update location for the dump in S3

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -2,7 +2,7 @@
 set -e
 
 # get the data from s3
-sudo -u deploy curl 'https://s3.amazonaws.com/gds-public-readable-tarballs/mapit-postgres93-May2016-dis-cty-hierarchy-and-la-names.sql.gz' -o mapit.sql.gz
+sudo -u deploy curl 'https://s3.amazonaws.com/gds-public-readable-tarballs/govuk-mapit/20160808-mapit-postgres93-May2016-dis-cty-hierarchy-and-la-names.sql.gz' -o mapit.sql.gz
 if ! echo "425080558e69471db3123744dd567559056aee1b  mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1


### PR DESCRIPTION
I've moved the mapit files into a directory in the same bucket today to keep
them more clearly separated from the other files in there, especially because
we're starting to mirror the source data there as well as keeping database
dumps. I also added the upload date to the start of the filenames so that they
sort more nicely. The file itself is unchanged so the hash doesn't change.