### PR TITLE
Upgrade MapIt to Django 1.8.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.14
+Django==1.8.16
 PyYAML==3.11
 Shapely==1.5.9
 argparse==1.2.1


### PR DESCRIPTION
This is a security release, but I don't think either of the issues affect us.
We should upgrade anyway to keep up to date.

https://www.djangoproject.com/weblog/2016/nov/01/security-releases/

https://trello.com/c/kJVvRPGG/543-upgrade-django-to-1-8-16-for-mapit