### PR TITLE
Send errors to Sentry

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -227,7 +227,13 @@ INSTALLED_APPS = [
     'django.contrib.gis',
     'django.contrib.staticfiles',
     'mapit',
+    'raven.contrib.django.raven_compat',
 ]
+
+RAVEN_CONFIG = {
+    'dsn': os.getenv('SENTRY_DSN'),
+    'environment': os.getenv('SENTRY_CURRENT_ENV'),
+}
 
 LOGGING = {
     'version': 1,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ pygdal==1.10.1.0
 python-memcached==1.54
 six==1.9.0
 wsgiref==0.1.2
+
+raven==6.1


### PR DESCRIPTION
This is the minimum config required.  Should the SENTRY_DSN env var not exist then it doesn't try to send anything.  Puppet has been deployed to make the env var available though so all should be well!

I tested this on dev by setting the SENTRY_DSN and then stopping postgres before making a request.

Once we've verified that this works on other environments we can look at removing the email alert configuration.

https://trello.com/c/ssAr2UCo/160-report-mapit-errors-to-sentry

https://trello.com/c/QwtfOcgR/22-update-mapit