### PR TITLE
Move configuration file to MapIt repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 .idea
-/conf/general.yml
 /conf/general.yml.deployed
 /conf/httpd.conf
 /conf/httpd.conf.deployed

--- a/conf/general.yml
+++ b/conf/general.yml
@@ -1,0 +1,52 @@
+# Adapted from general.yml-example
+
+# Connection details for database
+MAPIT_DB_NAME: 'mapit'
+MAPIT_DB_USER: 'mapit'
+# MAPIT_DB_PASS: 'obtained from environment variables'
+MAPIT_DB_HOST: '127.0.0.1'
+MAPIT_DB_PORT: null
+
+# Country is currently one of GB, NO, or KE. Optional; country specific things won't happen if not set.
+COUNTRY: 'GB'
+
+# An EPSG code for what the areas are stored as, e.g. 27700 is OSGB, 4326 for WGS84.
+# Optional, defaults to 4326.
+AREA_SRID: 27700
+
+# A secret key for this particular Django installation.
+# Set this to a random string -- the longer, the better.
+# DJANGO_SECRET_KEY: 'obtained from environment variables'
+
+# Mapped to Django's DEBUG and TEMPLATE_DEBUG settings. Optional, defaults to True.
+DEBUG: False
+
+# A list of IP addresses or User Agents that should be excluded from rate limiting. Optional.
+#  RATE_LIMIT: []
+
+# Email address that errors should be sent to. Optional.
+# BUGS_EMAIL: 'not used'
+# EMAIL_SUBJECT_PREFIX: 'not used '
+
+#########################################################################
+
+# You can ignore all of the settings below this point in the file
+# unless you want to use the scripts for setting up MapIt Global.
+
+# The scripts for setting up global MapIt rely on a Overpass API
+# server.  For bulk imports (e.g. setting up a instance of Global
+# MapIt) you should set up your own Overpass server locally, but for
+# generating a few KML files from OSM, it's easier to just use a
+# remote server.
+LOCAL_OVERPASS: False
+
+# If you want to use a local overpass server (i.e. LOCAL_OVERPASS is
+# True) then you should specify here the path to the database
+# directory.
+OVERPASS_DB_DIRECTORY: '/home/overpass/db/'
+
+# If you're using a remote overpass server (i.e. LOCAL_OVERPASS is
+# False) you should set its URL here. Please be aware that these
+# scripts can put a lot of load on the remote server, so set up your
+# own Overpass server for bulk imports.
+OVERPASS_SERVER: 'http://overpass-api.de/api/interpreter'


### PR DESCRIPTION
This configuration file exists for integration, staging and production in [alphagov-deployment][1].  We've now replaced the secrets held in the file with environment variables and removed the bits that make the configuration different.  This means that we can now use a generic `general.yml`, keep it
here and remove the old ones from alphagov-deployment.

Specifically, we've removed the rate limit configuration (as we allowed all the things that would send traffic to MapIt anyway), and removed the error email configuration as we now use Sentry.

(The old configuration is being removed in https://github.com/alphagov/alphagov-deployment/pull/9)

[1]: https://github.com/alphagov/alphagov-deployment/tree/b3c79cead97f8fe927d96215a0eeada9aa12b7e7/mapit/settings