### PR TITLE
Update Mapit data

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -2,8 +2,8 @@
 set -e
 
 # get the data from s3
-sudo -u deploy curl 'https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2017-09/20170919-mapit.sql.gz' -o mapit.sql.gz
-if ! echo "d36f15256a02032905307d51247a866993587001 mapit.sql.gz" | sha1sum -c -; then
+sudo -u deploy curl 'https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2018-01/20180124-mapit.sql.gz' -o mapit.sql.gz
+if ! echo "e036c72a637f48979e5f9ae957988eef61c12a82 mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1
 fi


### PR DESCRIPTION
This data has been produced using the updated script in our [mapit-scripts repo](https://github.com/alphagov/mapit-scripts/pull/2).

Running the updated import script on each MapIt server will allow us to use
postcodes that were issued after August 2017.

An example of a postcode that didn't exist before this version is "B78 1LJ" so we should ensure that it is found otherwise there's no point in any of this.

To test this, you should run the updated `import-db-from-s3.sh` script from your VM and ensure that it runs to completion.

Then, fire up Mapit:
```
govuk_setenv mapit ./startup.sh
```
and check that we get a sensible response for some postcodes (this one is in Saffron Walden, in Uttlesford District Council).  
```
curl http://localhost:3108/postcode/CB101HL
```

It's good to check some from around the UK, especially as the import for Northern Ireland is separate from other bits (BT1 1BG is in Belfast).