### PR TITLE
Change slug for Shepway Council to Folkestone & Hythe Council

### DIFF
--- a/mapit_gb/data/authorities.json
+++ b/mapit_gb/data/authorities.json
@@ -341,7 +341,7 @@
   "tunbridge-wells": {
     "gss": "E07000116"
   },
-  "shepway": {
+  "folkestone-hythe": {
     "gss": "E07000112"
   },
   "sevenoaks": {


### PR DESCRIPTION
The council has changed name, so we have to update the slug to match what's in local link manager