### PR TITLE
Improve importing docs

### DIFF
--- a/IMPORTING-DATA.md
+++ b/IMPORTING-DATA.md
@@ -166,7 +166,7 @@ To update a live mapit server we:
 
     There is a script in mapit:
     `mapit_gb/management/commands/mapit_UK_add_missing_codes.py` that
-    you can upate to add the codes once you work out if anything can
+    you can update to add the codes once you work out if anything can
     be done.
 
     Hopefully by the time the next releases happen GOV.UK will not rely
@@ -185,10 +185,11 @@ To update a live mapit server we:
 
     Ensure you test postcodes from all parts of the UK, since Northern
     Ireland data has been loaded separately.
+
 8.  Make PRs for any changes you had to make. You will have changed the
-    `import-uk-onspd` script in `mapit-scripts` to refer to new
-    datasets. If anything failed you may have had to change other things
-    in mapit too.
+    `import-uk-onspd` and `check-osni-downloads` script in `mapit-scripts` to
+    refer to new datasets. If anything failed you may have had to change other
+    things in mapit too.
 
 ### Export new database to S3
 
@@ -309,8 +310,7 @@ results:
     $ your laptop> ssh mapit-1.production
     $ mapit-1> /var/apps/mapit/test-samples.sh check
 
-Things you might have to fix
-----------------------------
+## Things you might have to fix
 
 The Office for National Statistics maintains a series of codes that represent a
 wide range of geographical areas of the UK. MapIt includes these and they are

--- a/IMPORTING-DATA.md
+++ b/IMPORTING-DATA.md
@@ -41,25 +41,19 @@ To update a live mapit server we:
 
 ### Generate a new database
 
-1.  Checkout the [Mapit](https://github.com/alphagov/mapit) repo to your
-    dev VM if you don't have it already.
+1.  Checkout the [mapit](https://github.com/alphagov/mapit) and
+    [mapit-scripts](https://github.com/alphagov/mapit-scripts) repos to your
+    development VM if you don't have it already. They should be in the
+    `/var/govuk` directory.
+
 2.  Prepare your mapit repo so that you can run the importer scripts:
-    1.  Run `govuk_setenv mapit ./startup.sh` - this will install all dependencies and run
-        the server, once the server is running you can kill it, we just
-        wanted the dependencies installed.
-    2.  Prepare your database for importing new data by running the
-        following to create an empty database and migrate it to the
-        empty mapit schema:
+    1. Run `govuk_setenv mapit ./startup.sh` - this will install all
+       dependencies and run the server, once the server is running you can kill
+       it, we just wanted the dependencies installed.
+    2. Run `govuk_setenv mapit ./reset-db.sh` - this will drop any existing
+       database, create a new empty one and migrate it to the empty schema.
 
-            $ sudo -u postgres dropdb mapit
-            $ sudo -u postgres createdb --owner mapit mapit
-            $ sudo -u postgres psql -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
-            $ govuk_setenv mapit .venv/bin/python ./manage.py migrate
-
-3.  Checkout the [mapit-scripts](https://github.com/alphagov/mapit-scripts)
-    repo to your dev VM if you don't have it already.
-
-4.  Find the latest ONS Postcode Database, Boundary Line, and
+3.  Find the latest ONS Postcode Database, Boundary Line, and
     OSNI datasets.
     1.  MySociety may have mirrored the latest datasets on their cache
         server: <http://parlvid.mysociety.org/os/> so check there first.
@@ -87,7 +81,7 @@ To update a live mapit server we:
         Wards 2012 datasets at the moment, future legislation may introduce a
         Wards 2020 dataset).
 
-5.  Update the `import-uk-onspd` script in `mapit-scripts` to refer to
+4.  Update the `import-uk-onspd` script in `mapit-scripts` to refer to
     the urls and filenames of the new releases instead of the old ones.
 
     Note that the package of OSNI data that is mirrored on mysociety's
@@ -113,7 +107,7 @@ To update a live mapit server we:
     29900 (the UK projection), 4326 (the web mercator projection used
     by google earth among others).
 
-6.  Run the `import-uk-onspd` script to import the data:
+5.  Run the `import-uk-onspd` script to import the data:
 
         $ ./import-uk-onspd
 
@@ -148,7 +142,7 @@ To update a live mapit server we:
     the database and run the scripts again from scratch. Idempotency is
     patchy.
 
-7.  Check for missing codes.
+6.  Check for missing codes.
 
     The ONS used to identify areas with snac codes (called ons
     in mapit). They stopped doing this in 2011 and started using GSS
@@ -173,8 +167,8 @@ To update a live mapit server we:
 
     Hopefully by the time the next releases happen GOV.UK will not rely
     on ONS/snac codes and this will cease being an issue.
-    
-8.  Test some postcodes.
+
+7.  Test some postcodes.
 
     If you've had users complaining that their postcode isn't
     recognised, then try _those_ postcodes and any other ones
@@ -185,9 +179,9 @@ To update a live mapit server we:
     You should expect a `200` response with data present in the `areas`
     field of the response.
 
-    Ensure you test postcodes from all parts of the UK, since Northern 
+    Ensure you test postcodes from all parts of the UK, since Northern
     Ireland data has been loaded separately.
-9.  Make PRs for any changes you had to make. You will have changed the
+8.  Make PRs for any changes you had to make. You will have changed the
     `import-uk-onspd` script in `mapit-scripts` to refer to new
     datasets. If anything failed you may have had to change other things
     in mapit too.
@@ -330,4 +324,3 @@ in case they change. An example of doing this is [frontend PR 948]
 (https://github.com/alphagov/frontend/pull/948) (when the file was still
 residing in Frontend,[it has been moved it to MapIt since]
 (https://github.com/alphagov/mapit/pull/20)).
-


### PR DESCRIPTION
This improves the importing docs to make it easier to complete the process. See individual commits for more details.

[Trello Card](https://trello.com/c/eCBcegb3/781-dry-run-of-importing-ons-postcode-and-os-boundary-line-data)