### PR TITLE
Add codes for missing authorities

### DIFF
--- a/mapit_gb/data/authorities.json
+++ b/mapit_gb/data/authorities.json
@@ -1252,5 +1252,14 @@
   },
   "ards-and-north-down": {
     "gss": "N09000011"
+  },
+  "east-suffolk": {
+    "gss": "E07000244"
+  },
+  "somerset-west-taunton": {
+    "gss": "E07000246"
+  },
+  "west-suffolk": {
+    "gss": "E07000245"
   }
 }

--- a/mapit_gb/data/authorities.json
+++ b/mapit_gb/data/authorities.json
@@ -1261,5 +1261,14 @@
   },
   "west-suffolk": {
     "gss": "E07000245"
+  },
+  "bournemouth-christchurch-poole": {
+    "gss": "E06000058"
+  },
+  "dorset": {
+    "gss": "E06000059"
+  },
+  "north-lanarkshire": {
+    "gss": "S12000050"
   }
 }

--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -64,6 +64,9 @@ class Command(BaseCommand):
             MissingOnsCode(code='E07000244', area_type='DIS', area_name='East Suffolk District Council'),
             MissingOnsCode(code='E07000246', area_type='DIS', area_name='Somerset West and Taunton District Council'),
             MissingOnsCode(code='E07000245', area_type='DIS', area_name='West Suffolk District Council'),
+            MissingOnsCode(code='E06000058', area_type='UTA', area_name='Bournemouth, Christchurch and Poole Council'),
+            MissingOnsCode(code='E06000059', area_type='UTA', area_name='Dorset Council'),
+            MissingOnsCode(code='S12000050', area_type='UTA', area_name='North Lanarkshire Council'),
         ]
 
 

--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -59,6 +59,11 @@ class Command(BaseCommand):
             MissingOnsCode(code='N09000009', area_type='LGD', area_name='Mid Ulster District Council'),
             MissingOnsCode(code='N09000010', area_type='LGD', area_name='Newry, Mourne and Down District Council'),
             MissingOnsCode(code='N09000011', area_type='LGD', area_name='Ards and North Down Borough Council'),
+
+            # https://geoportal.statistics.gov.uk/datasets/local-authority-district-to-county-april-2019-lookup-in-england
+            MissingOnsCode(code='E07000244', area_type='DIS', area_name='East Suffolk District Council'),
+            MissingOnsCode(code='E07000246', area_type='DIS', area_name='Somerset West and Taunton District Council'),
+            MissingOnsCode(code='E07000245', area_type='DIS', area_name='West Suffolk District Council'),
         ]
 
 


### PR DESCRIPTION
This adds missing codes for authorities based on https://geoportal.statistics.gov.uk/datasets/local-authority-district-to-county-april-2019-lookup-in-england.

```
12 EUR areas in current generation
  2 EUR areas have no ons code:
    Northern Ireland 11874 (gen 1-1) Northern Ireland
    Scotland 9200 (gen 1-1) Scotland
26 CTY areas in current generation
192 DIS areas in current generation
  3 DIS areas have no ons code:
    East Suffolk District Council 2044 (gen 1-1) England
    Somerset West and Taunton District Council 2068 (gen 1-1) England
    West Suffolk District Council 2043 (gen 1-1) England
  3 DIS areas have no govuk_slug code:
    East Suffolk District Council 2044 (gen 1-1) England
    Somerset West and Taunton District Council 2068 (gen 1-1) England
    West Suffolk District Council 2043 (gen 1-1) England
33 LBO areas in current generation
11 LGD areas in current generation
36 MTD areas in current generation
109 UTA areas in current generation
  3 UTA areas have no ons code:
    Bournemouth, Christchurch and Poole Council 1805 (gen 1-1) England
    Dorset Council 1792 (gen 1-1) England
    North Lanarkshire Council 1814 (gen 1-1) Scotland
  4 UTA areas have no govuk_slug code:
    Bournemouth, Christchurch and Poole Council 1805 (gen 1-1) England
    Dorset Council 1792 (gen 1-1) England
    Glasgow City Council 1812 (gen 1-1) Scotland
    North Lanarkshire Council 1814 (gen 1-1) Scotland
1 COI areas in current generation
```

[Trello Card](https://trello.com/c/g6GfxrJk/987-update-mapit-to-include-changes-in-organisation)