### PR TITLE
Exit on the first error in the reset-db.sh script

### DIFF
--- a/reset-db.sh
+++ b/reset-db.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 sudo -u postgres dropdb mapit
 sudo -u postgres createdb --owner mapit mapit
 sudo -u postgres psql -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit


### PR DESCRIPTION
So if dropping the database fails, the script stops there, rather than
going on to try and create the database.