### PR TITLE
Fixes to import May 2019 (August update) data

### DIFF
--- a/mapit/management/find_parents.py
+++ b/mapit/management/find_parents.py
@@ -46,7 +46,11 @@ class FindParentsCommand(BaseCommand):
                 except Area.DoesNotExist:
                     continue
             if not parent:
-                raise Exception("Area %s does not have a parent?" % (self.pp_area(area)))
+                # Fix for May 2019 August update
+                if self.pp_area(area) == 'WARREN [11574] (LGW)' and options['commit']:
+                    parent = Area.objects.get(name='Bangor East and Donaghadee') # id=11758 (LGE)
+                else:
+                    raise Exception("Area %s does not have a parent?" % (self.pp_area(area)))
             if area.parent_area != parent:
                 self.stdout.write("Parent for %s was %s, is now %s" % (
                     self.pp_area(area), self.pp_area(area.parent_area), self.pp_area(parent)))

--- a/mapit/management/find_parents.py
+++ b/mapit/management/find_parents.py
@@ -41,7 +41,7 @@ class FindParentsCommand(BaseCommand):
                         args['type__code'] = self.parentmap[area.type.code]
                     else:
                         args['type__code__in'] = self.parentmap[area.type.code]
-                    parent = Area.objects.get(**args)
+                    parent = Area.objects.filter(**args).first()
                     break
                 except Area.DoesNotExist:
                     continue

--- a/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
+++ b/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
@@ -64,6 +64,8 @@ class Command(LabelCommand):
                 ons_code = patch['ons-code']
             elif 'unit-id' in patch:
                 unit_id = patch['unit-id']
+            elif 'name' in patch:
+                name = patch['name']
 
             if area_code == 'NCP':
                 continue  # Ignore Non Parished Areas
@@ -197,5 +199,9 @@ class Command(LabelCommand):
         if name in ('Kirby-le-Soken & Hamford Ward', 'Thorpe, Beaumont & Great Holland Ward') and \
                 area_code == 'DIW' and unit_id == '174247':
             return {'unit-id': None}
+
+        # May (August update) 2019 name correction
+        if name == 'Highland and Islands PER' and ons_code == 'S17000011':
+            return {'name':'Highlands and Islands PER'}
 
         return {}


### PR DESCRIPTION
There were some issues with a couple of areas, these fixes allow the script to run to completion:

```
12 EUR areas in current generation
  2 EUR areas have no ons code:
    Northern Ireland 11874 (gen 1-1) Northern Ireland
    Scotland 9199 (gen 1-1) Scotland
26 CTY areas in current generation
192 DIS areas in current generation
33 LBO areas in current generation
11 LGD areas in current generation
36 MTD areas in current generation
109 UTA areas in current generation
1 COI areas in current generation
```

I have tested various postcodes as well as some that didn't exist before e.g. "S2 4FT"
 I have also run the `mapit_UK_show_missing_codes` in `integration` to check the output matches.

Trello card: https://trello.com/c/luOhMYX6/1267-5-update-mapit-with-latest-postcode-data-%F0%9F%8D%90

