### PR TITLE
Changes for govuk-docker

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -89,7 +89,7 @@ DATABASES = {
         'NAME': config.get('MAPIT_DB_NAME', 'mapit'),
         'USER': config.get('MAPIT_DB_USER', 'mapit'),
         'PASSWORD': MAPIT_DB_PASS,
-        'HOST': config.get('MAPIT_DB_HOST', ''),
+        'HOST': os.environ.get('MAPIT_DB_HOST', config.get('MAPIT_DB_HOST', '')),
         'PORT': config.get('MAPIT_DB_PORT', ''),
     }
 }


### PR DESCRIPTION
This is necessary to allow the docker network to work as otherwise it
defaults to local host and postgres runs in a separate container.

[trello](https://trello.com/c/QXBhaFlh/1449-5-add-mapit-to-govuk-docker)