### PR TITLE
Prepare for Python 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,15 +14,15 @@ node {
     }
 
     stage('Installing Packages') {
-      sh("rm -rf ./venv")
-      sh("virtualenv --no-site-packages ./venv")
-      sh("./venv/bin/python ./venv/bin/pip -q install --upgrade pip wheel setuptools")
-      sh("./venv/bin/python ./venv/bin/pip -q install -r requirements.txt")
+      sh("rm -rf venv")
+      sh("virtualenv -p python3 --no-site-packages venv")
+      sh("venv/bin/python -m pip -q install --upgrade pip wheel setuptools")
+      sh("venv/bin/python -m pip -q install -r requirements.txt")
     }
 
     stage('Tests') {
       govuk.setEnvar("GOVUK_ENV", "ci")
-      sh("./venv/bin/python manage.py test mapit mapit_gb")
+      sh("venv/bin/python manage.py test mapit mapit_gb")
     }
 
     if (env.BRANCH_NAME == 'master') {

--- a/reset-db.sh
+++ b/reset-db.sh
@@ -5,4 +5,4 @@ set -ex
 sudo -u postgres dropdb mapit
 sudo -u postgres createdb --owner mapit mapit
 sudo -u postgres psql -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
-govuk_setenv mapit .venv/bin/python ./manage.py migrate
+govuk_setenv mapit .venv/bin/python manage.py migrate

--- a/startup.sh
+++ b/startup.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 DIRECTORY='.venv'
 if [ ! -d "$DIRECTORY" ]; then
-  virtualenv --no-site-packages "$DIRECTORY"
+  virtualenv -p python3 --no-site-packages "$DIRECTORY"
 fi
 
-$DIRECTORY/bin/pip install --upgrade pip wheel setuptools
-$DIRECTORY/bin/pip install -r requirements.txt
-$DIRECTORY/bin/python ./manage.py migrate -v 0
-$DIRECTORY/bin/python ./manage.py runserver 3108
+$DIRECTORY/bin/python -m pip install --upgrade pip wheel setuptools
+$DIRECTORY/bin/python -m pip install -r requirements.txt
+$DIRECTORY/bin/python manage.py migrate -v 0
+$DIRECTORY/bin/python manage.py runserver 3108


### PR DESCRIPTION
This ensures that the app runs under Python 3 both locally and in CI.

I've decided not to go down the route of supporting both Python 2 and Python 3 in those environments since I imagine we will have switched over to running Python 3 in production pretty soon so we don't need to worry too much about the temporary difference.

[Trello Card](https://trello.com/c/DzbcRdub/1501-5-deploy-mapit-using-python-3)