### PR TITLE
Update to use Docker for local development

### DIFF
--- a/reset-db.sh
+++ b/reset-db.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-sudo -u postgres dropdb mapit
-sudo -u postgres createdb --owner mapit mapit
-sudo -u postgres psql -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
-govuk_setenv mapit .venv/bin/python manage.py migrate
+psql -U postgres -c "DROP DATABASE mapit;"
+createdb -U postgres --owner mapit mapit
+psql -U postgres -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
+python ./manage.py migrate -v 0


### PR DESCRIPTION
Mapit has now been configured to run in Docker.

I've tested out the scripts in my Docker container and have imported the data successfully.
The results match our latest import:

```
11874 areas in current generation (1)

Checking ['EUR', 'CTY', 'DIS', 'LBO', 'LGD', 'MTD', 'UTA', 'COI'] for missing ['ons', 'gss', 'govuk_slug']
12 EUR areas in current generation
  2 EUR areas have no ons code:
    Northern Ireland 11874 (gen 1-1) Northern Ireland
    Scotland 9199 (gen 1-1) Scotland
26 CTY areas in current generation
192 DIS areas in current generation
33 LBO areas in current generation
11 LGD areas in current generation
36 MTD areas in current generation
109 UTA areas in current generation
1 COI areas in current generation
```

Related PRS:
https://github.com/alphagov/mapit-scripts/pull/8

Trello card: https://trello.com/c/mJVTfjjd/1719-8-import-mapit-data-using-docker-%F0%9F%8D%90