### PR TITLE
Update Python version in Jenkinsfile to 3.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
 
     stage('Installing Packages') {
       sh("rm -rf venv")
-      sh("virtualenv -p python3 --no-site-packages venv")
+      sh("virtualenv -p python3.5 --no-site-packages venv")
       sh("venv/bin/python -m pip -q install --upgrade pip wheel setuptools")
       sh("venv/bin/python -m pip -q install -r requirements.txt")
     }


### PR DESCRIPTION
We require Python version `3.5` or later for our Jenkins
builds to pass.

Trello card: https://trello.com/c/lR6qMIm1/1780-5-upgrade-to-a-supported-python-version