### PR TITLE
Import feb 2020 data

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -2,8 +2,8 @@
 set -e
 
 # get the data from s3
-sudo -u deploy curl 'https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/mapit-may-2019-august-update.sql.gz' -o mapit.sql.gz
-if ! echo "f13a7431ed55fb818c89f959d5570d92289ba525 mapit.sql.gz" | sha1sum -c -; then
+sudo -u deploy curl 'https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-02/mapit-march-2020-feb-update.sql.gz' -o mapit.sql.gz
+if ! echo "8a792e4d7dbed15e6d1a392aa9e82ec64de91333 mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1
 fi


### PR DESCRIPTION
The latest version of data, Feb 2020, has been uploaded to S3. This script is updated in order to download the new data.

Trello: https://trello.com/c/6ss0MKQw/1783-8-import-new-mapit-data-using-docker.