### PR TITLE
Improve docs on exporting database

### DIFF
--- a/IMPORTING-DATA.md
+++ b/IMPORTING-DATA.md
@@ -209,7 +209,7 @@ To update a live mapit server we:
 
 Export the database you just built in your container:
 
-    $ govuk-docker run mapit-app psql -U postgres pg_dump mapit | gzip > mapit.sql.gz
+    $ govuk-docker run mapit-app pg_dump -U postgres mapit | gzip > mapit.sql.gz
 
 It should be \~500Mb in size. You'll want to give it a name that refers
 to what data it contains. Perhaps `mapit-<%b%Y>.sql.gz` (using

--- a/IMPORTING-DATA.md
+++ b/IMPORTING-DATA.md
@@ -211,7 +211,7 @@ Export the database you just built in your container:
 
     $ govuk-docker run mapit-app pg_dump -U postgres mapit | gzip > mapit.sql.gz
 
-It should be \~500Mb in size. You'll want to give it a name that refers
+**It should be \~500Mb in size.** You'll want to give it a name that refers
 to what data it contains. Perhaps `mapit-<%b%Y>.sql.gz` (using
 `strftime` parlance) for a standard release, or
 `mapit-<%b%Y>-<a-description-of-change>.sql.gz` if you've had to change

--- a/IMPORTING-DATA.md
+++ b/IMPORTING-DATA.md
@@ -221,14 +221,19 @@ Arrange to have the file you just created uploaded to the
 `govuk-custom-formats-mapit-storage-production` S3 bucket and ensure that
 it's permission is set to `public`.
 
-Once it's been uploaded change the URL and checksum (using
-`sha1sum <your-mapit-file.sql.gz>`) reference in `import-db-from-s3.sh`
-to refer to your new file. Submit change as a PR against
-[Mapit](https://github.com/alphagov/mapit) and deploy once it's been approved.
-
 ### Update servers with new database
 
-NB: THIS REQUIRES ACCESS TO GOV.UK PRODUCTION
+**NB: THIS REQUIRES ACCESS TO GOV.UK PRODUCTION**
+
+Once the data has been uploaded change the URL and checksum (using
+`sha1sum <your-mapit-file.sql.gz>`) reference in `import-db-from-s3.sh`
+to refer to your new file. Submit change as a PR against
+[Mapit](https://github.com/alphagov/mapit) and deploy following the normal
+process.
+
+**Note: Only deploy this change to production once the new data has been tested
+in staging. If a new Mapit machine gets created in AWS, it will automatically
+try importing the data.**
 
 Now that your changes have been deployed, you can test the new database in
 `AWS staging` before moving to production.


### PR DESCRIPTION
The command was wrong and the resulting file was accidentally uploaded to S3 and deployed to production, so hopefully this should make it clearer and avoid it happening again.