### PR TITLE
Fix database URL shasum

### DIFF
--- a/import-db-from-s3.sh
+++ b/import-db-from-s3.sh
@@ -3,7 +3,7 @@ set -e
 
 # get the data from s3
 sudo -u deploy curl 'https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-02/mapit-march-2020-feb-update.sql.gz' -o mapit.sql.gz
-if ! echo "8a792e4d7dbed15e6d1a392aa9e82ec64de91333 mapit.sql.gz" | sha1sum -c -; then
+if ! echo "23d127ef152292f800476c479f511e9f09d6fb46 mapit.sql.gz" | sha1sum -c -; then
   echo "SHA1 does not match downloaded file!"
   exit 1
 fi


### PR DESCRIPTION
I've uploaded a new database dump, which means that the shasum has changed.

The original file accidentally contained no data which meant that when mapit tried to import it, it wouldn't work.