### PR TITLE
Add missing brackets to print statements

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_show_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_show_missing_codes.py
@@ -29,44 +29,44 @@ class Command(BaseCommand):
             generation_low__lte=current_generation,
             generation_high__gte=current_generation
         )
-        print '{count} areas in current generation ({gen_id})\n'.format(
+        print('{count} areas in current generation ({gen_id})\n'.format(
             count=current_areas.count(),
             gen_id=current_generation.id
-        )
+        ))
 
         used_area_types = options['area_types'].split(',')
         used_code_types = options['code_types'].split(',')
 
-        print 'Checking {area_types} for missing {code_types}'.format(
+        print('Checking {area_types} for missing {code_types}'.format(
             area_types=used_area_types,
             code_types=used_code_types
-        )
+        ))
 
         for area_type in used_area_types:
             areas = current_areas.filter(type__code=area_type)
-            print '{count} {type} areas in current generation'.format(
+            print('{count} {type} areas in current generation'.format(
                 count=areas.count(),
                 type=area_type
-            )
+            ))
             for code_type in used_code_types:
                 if self.is_code_type_not_required_for_area_type(code_type, area_type):
                     continue
 
                 areas_without_codes = areas.exclude(codes__type__code=code_type)
                 if areas_without_codes.count() > 0:
-                    print '  {count} {type} areas have no {code_type} code:'.format(
+                    print('  {count} {type} areas have no {code_type} code:'.format(
                         count=areas_without_codes.count(),
                         type=area_type,
                         code_type=code_type
-                    )
+                    ))
                     for area in areas_without_codes:
-                        print '    {name} {id} (gen {gen_low}-{gen_high}) {country}'.format(
+                        print('    {name} {id} (gen {gen_low}-{gen_high}) {country}'.format(
                             name=area.name,
                             id=area.id,
                             gen_low=area.generation_low_id,
                             gen_high=area.generation_high_id,
                             country=area.country
-                        )
+                        ))
 
     def is_code_type_not_required_for_area_type(self, code_type, area_type):
         return (code_type == "govuk_slug" and area_type == "EUR")


### PR DESCRIPTION
The script mapit_UK_show_missing_codes was throwing syntax errors due to the upgrade to python3. We need brackets around the print statements in order to run the script in python3.