### PR TITLE
Double mapit unicorn workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/mapit/app.pid  -- project.wsgi:application --bind 127.0.0.1:3108 --workers 8
+web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/mapit/app.pid  -- project.wsgi:application --bind 127.0.0.1:3108 --workers 16


### PR DESCRIPTION
The green line (memory used) is consistently below 700MiB, but the red line (memory available) is 3.8GiB.  We should be able to more than double the workers.

<img width="1917" alt="Screenshot 2020-12-21 at 16 01 07" src="https://user-images.githubusercontent.com/75235/102796339-01471580-43a6-11eb-9e98-691f02ccaf8d.png">

We use a `UNICORN_WORKER_PROCESSES` env var for our Ruby apps, so we can have different numbers of workers in different environments.  But that's a [govuk_app_config thing](https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_unicorn.rb#L3), and [since mapit is configured as a "procfile" app](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/mapit.pp#L30) we can't adjust the unicorn herder config from inside the app anyway.

So every environment will run with the same number of unicorn workers, which means if we want to increase further we'll need to resize integration to use bigger instances.