### PR TITLE
Fix Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ node {
     stage('Installing Packages') {
       sh("rm -rf venv")
       sh("virtualenv -p python3.5 --no-site-packages venv")
-      sh("venv/bin/python -m pip -q install --upgrade pip wheel setuptools")
-      sh("venv/bin/python -m pip -q install -r requirements.txt")
+      sh("venv/bin/python -m pip install --upgrade pip wheel setuptools")
+      sh("venv/bin/python -m pip install -r requirements.txt")
     }
 
     stage('Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
 
     stage('Installing Packages') {
       sh("rm -rf venv")
-      sh("virtualenv -p python3.5 --no-site-packages venv")
+      sh("python3.6 -m venv venv")
       sh("venv/bin/python -m pip install --upgrade pip wheel setuptools")
       sh("venv/bin/python -m pip install -r requirements.txt")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
 
     stage('Tests') {
       govuk.setEnvar("GOVUK_ENV", "ci")
-      sh("venv/bin/python manage.py test mapit mapit_gb")
+      sh("venv/bin/python manage.py test --noinput mapit mapit_gb")
     }
 
     if (env.BRANCH_NAME == 'master') {

--- a/mapit/tests/test_query_args.py
+++ b/mapit/tests/test_query_args.py
@@ -32,8 +32,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             )
         )
 
@@ -42,8 +42,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(type__code='WMC'))
         )
 
@@ -52,8 +52,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(type__code__in=['WMC', 'EUR']))
         )
 
@@ -62,8 +62,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(type__code='WMC'))
         )
 
@@ -72,8 +72,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(type__code__in=['WMC', 'EUR']))
         )
 
@@ -85,8 +85,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.old_generation.id,
                 generation_low__lte=self.old_generation.id,
+                generation_high__gte=self.old_generation.id,
             )
         )
 
@@ -98,8 +98,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.old_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.old_generation.id,
             )
         )
 
@@ -108,8 +108,8 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(country__code='DE') | Q(countries__code='DE'))
         )
 
@@ -118,7 +118,7 @@ class QueryArgsTest(TestCase):
         self.q_equality(
             q,
             Q(
-                generation_high__gte=self.active_generation.id,
                 generation_low__lte=self.active_generation.id,
+                generation_high__gte=self.active_generation.id,
             ) & (Q() | Q(country__code__in=['DE', 'FR']) | Q(countries__code__in=['DE', 'FR']))
         )


### PR DESCRIPTION
This fixes the Jenkins build, so we build Mapit using Python 3.6 and fix query argument tests.

In addition to this, the build also failed because we had upgraded to Postgres 9.6 (from 9.3) but didn't install PostGIS.  This was fixed in https://github.com/alphagov/govuk-puppet/pull/10935 and https://github.com/alphagov/govuk-puppet/pull/10936.

Trello card: https://trello.com/c/hirdtB41