### PR TITLE
Fixes to import November 2020 data

### DIFF
--- a/mapit/management/find_parents.py
+++ b/mapit/management/find_parents.py
@@ -47,8 +47,8 @@ class FindParentsCommand(BaseCommand):
                 except Area.DoesNotExist:
                     continue
             if not parent:
-                # Fix for May 2019 August update
-                if self.pp_area(area) == 'WARREN [11574] (LGW)' and options['commit']:
+                # Fix for May 2020 update
+                if self.pp_area(area) == 'WARREN [11570] (LGW)' and options['commit']:
                     parent = Area.objects.get(name='Bangor East and Donaghadee')  # id=11758 (LGE)
                 else:
                     raise Exception("Area %s does not have a parent?" % (self.pp_area(area)))

--- a/mapit_gb/data/authorities.json
+++ b/mapit_gb/data/authorities.json
@@ -1,6 +1,6 @@
 {
   "buckinghamshire": {
-    "gss": "E10000002"
+    "gss": "E06000060"
   },
   "cambridgeshire": {
     "gss": "E10000003"
@@ -187,24 +187,6 @@
   },
   "exeter": {
     "gss": "E07000041"
-  },
-  "purbeck": {
-    "gss": "E07000051"
-  },
-  "christchurch": {
-    "gss": "E07000048"
-  },
-  "west-dorset": {
-    "gss": "E07000052"
-  },
-  "east-dorset": {
-    "gss": "E07000049"
-  },
-  "north-dorset": {
-    "gss": "E07000050"
-  },
-  "weymouth-and-portland": {
-    "gss": "E07000053"
   },
   "lewes": {
     "gss": "E07000063"
@@ -548,14 +530,8 @@
   "oxford": {
     "gss": "E07000178"
   },
-  "west-somerset": {
-    "gss": "E07000191"
-  },
   "mendip": {
     "gss": "E07000187"
-  },
-  "taunton-deane": {
-    "gss": "E07000190"
   },
   "south-somerset": {
     "gss": "E07000189"
@@ -587,20 +563,8 @@
   "tamworth": {
     "gss": "E07000199"
   },
-  "waveney": {
-    "gss": "E07000206"
-  },
   "babergh": {
     "gss": "E07000200"
-  },
-  "suffolk-coastal": {
-    "gss": "E07000205"
-  },
-  "st-edmundsbury": {
-    "gss": "E07000204"
-  },
-  "forest-heath": {
-    "gss": "E07000201"
   },
   "mid-suffolk": {
     "gss": "E07000203"
@@ -920,9 +884,6 @@
   "blaenau-gwent": {
     "gss": "W06000019"
   },
-  "bournemouth": {
-    "gss": "E06000028"
-  },
   "bracknell-forest": {
     "gss": "E06000036"
   },
@@ -1036,9 +997,6 @@
   },
   "perth-and-kinross": {
     "gss": "S12000048"
-  },
-  "poole": {
-    "gss": "E06000029"
   },
   "powys": {
     "gss": "W06000023"

--- a/mapit_gb/data/authorities.json
+++ b/mapit_gb/data/authorities.json
@@ -101,18 +101,6 @@
   "bedford": {
     "gss": "E06000055"
   },
-  "wycombe": {
-    "gss": "E07000007"
-  },
-  "south-bucks": {
-    "gss": "E07000006"
-  },
-  "chiltern": {
-    "gss": "E07000005"
-  },
-  "aylesbury-vale": {
-    "gss": "E07000004"
-  },
   "fenland": {
     "gss": "E07000010"
   },

--- a/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
+++ b/mapit_gb/management/commands/mapit_UK_add_missing_codes.py
@@ -67,6 +67,9 @@ class Command(BaseCommand):
             MissingOnsCode(code='E06000058', area_type='UTA', area_name='Bournemouth, Christchurch and Poole Council'),
             MissingOnsCode(code='E06000059', area_type='UTA', area_name='Dorset Council'),
             MissingOnsCode(code='S12000050', area_type='UTA', area_name='North Lanarkshire Council'),
+
+            # https://geoportal.statistics.gov.uk/datasets/f7ba20849bc54f58bbb8ef14c640f9a9_0
+            MissingOnsCode(code='E06000060', area_type='UTA', area_name='Buckinghamshire Council'),
         ]
 
 

--- a/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
+++ b/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
@@ -71,13 +71,7 @@ class Command(BaseCommand):
                         'Perth and Kinross Council': 'S12000024'
                     }
 
-                    if official_name or gss_code in merged_authorities:
-                        print('Area for {authority} {gss_code} not found'.format(
-                            authority=official_name,
-                            gss_code=gss_code
-                        ))
-                        print('(has been changed or merged with another area)')
-                    else:
+                    if official_name not in merged_authorities and gss_code not in merged_authorities:
                         print('Area for {authority} {gss_code} not found'.format(
                             authority=official_name,
                             gss_code=gss_code

--- a/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
+++ b/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
@@ -68,7 +68,8 @@ class Command(BaseCommand):
                         'Fife Council': 'S12000015',
                         'Glasgow City Council': 'S12000046',
                         'North Lanarkshire Council': 'S12000044',
-                        'Perth and Kinross Council': 'S12000024'
+                        'Perth and Kinross Council': 'S12000024',
+                        'Buckinghamshire County Council': 'E06000060'
                     }
 
                     if official_name not in merged_authorities and gss_code not in merged_authorities:

--- a/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
+++ b/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py
@@ -69,7 +69,11 @@ class Command(BaseCommand):
                         'Glasgow City Council': 'S12000046',
                         'North Lanarkshire Council': 'S12000044',
                         'Perth and Kinross Council': 'S12000024',
-                        'Buckinghamshire County Council': 'E06000060'
+                        'Buckinghamshire County Council': 'E10000002',
+                        'Aylesbury Vale District Council': 'E07000004',
+                        'Chiltern District Council': 'E07000005',
+                        'South Bucks District Council': 'E07000006',
+                        'Wycombe District Council': 'E07000007'
                     }
 
                     if official_name not in merged_authorities and gss_code not in merged_authorities:

--- a/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py
+++ b/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py
@@ -31,33 +31,7 @@ class Command(BaseCommand):
                 except Area.DoesNotExist:
                     # An area that existed at the time of the mapping, but no longer
 
-                    # List of known areas that no longer exist or have been
-                    # merged with another
-                    merged_authorities = {
-                        'north-dorset': 'E07000050',
-                        'bournemouth': 'E06000028',
-                        'christchurch': 'E07000048',
-                        'forest-heath': 'E07000201',
-                        'poole': 'E06000029',
-                        'west-somerset': 'E07000191',
-                        'purbeck': 'E07000051',
-                        'weymouth-and-portland': 'E07000053',
-                        'east-dorset': 'E07000049',
-                        'west-dorset': 'E07000052',
-                        'st-edmundsbury': 'E07000204',
-                        'taunton-deane': 'E07000190',
-                        'suffolk-coastal': 'E07000205',
-                        'waveney': 'E07000206'
-                    }
-
-                    if slug or gss_code in merged_authorities:
-                        print('Area for {authority} {gss_code} not found'.format(
-                            authority=slug,
-                            gss_code=gss_code
-                        ))
-                        print('(has been changed or merged with another area)')
-                    else:
-                        print('Area for {authority} {gss_code} not found'.format(
-                            authority=slug,
-                            gss_code=gss_code
-                        ))
+                    print('Area for {authority} {gss_code} not found'.format(
+                        authority=slug,
+                        gss_code=gss_code
+                    ))


### PR DESCRIPTION
We had a few issues when trying to import the latest [November 2020 data](https://github.com/alphagov/mapit/blob/master/HISTORY.md#november-2020-import). These changes allow us to successfully import the data:

```
    11870 areas in current generation (1)

    Checking ['EUR', 'CTY', 'DIS', 'LBO', 'LGD', 'MTD', 'UTA', 'COI'] for missing ['ons', 'gss', 'govuk_slug']
    12 EUR areas in current generation
      2 EUR areas have no ons code:
        Northern Ireland 11870 (gen 1-1) Northern Ireland
        Scotland 9195 (gen 1-1) Scotland
    25 CTY areas in current generation
    188 DIS areas in current generation
    33 LBO areas in current generation
    11 LGD areas in current generation
    36 MTD areas in current generation
    110 UTA areas in current generation
      1 UTA areas have no ons code:
        Buckinghamshire Council 1767 (gen 1-1) England
      1 UTA areas have no govuk_slug code:
        Buckinghamshire Council 1767 (gen 1-1) England
    1 COI areas in current generation
```

See individual commits for more detail.

Trello card: https://trello.com/c/rm2WTeqk/2331-pull-upstream-mapit-changes-from-mysociety



