### PR TITLE
Ensure Mapit output and errors are logged

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/mapit/app.pid  -- project.wsgi:application --bind 127.0.0.1:3108 --workers 16
+web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/mapit/app.pid  -- project.wsgi:application --bind 127.0.0.1:3108 --workers 16 --log-file /var/log/mapit/app.out.log --error-logfile /var/log/mapit/app.err.log


### PR DESCRIPTION
Previously errors were being logged to STDERR, which gunicorn or unicornherder was masking.

This was inspired by the same change we made for CKAN in https://github.com/alphagov/ckanext-datagovuk/pull/91.

Trello card: https://trello.com/c/rm2WTeqk