### PR TITLE
Set cache location from env var and increase cache time

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -66,7 +66,7 @@ else:
         }
     except ImportError:
         pass
-    CACHE_MIDDLEWARE_SECONDS = 86400
+    CACHE_MIDDLEWARE_SECONDS = 2419200  # 4 weeks
     CACHE_MIDDLEWARE_KEY_PREFIX = config.get('MAPIT_DB_NAME')
 
 if config.get('BUGS_EMAIL'):

--- a/project/settings.py
+++ b/project/settings.py
@@ -60,7 +60,7 @@ else:
         CACHES = {
             'default': {
                 'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-                'LOCATION': '127.0.0.1:11211',
+                'LOCATION': os.environ.get('MEMCACHE_SERVERS', '127.0.0.1:11211'),
                 'TIMEOUT': 86400,
             }
         }


### PR DESCRIPTION
This PR allows the use of "MAPIT_CACHE_LOCATION" to override the default location of memcached. It also increases the cache time to a week to make better use of the cache, as Mapit data is update infrequently.