### PR TITLE
Fix govuk-developer-docs importing of this doc

### DIFF
--- a/docs/testing-server.md
+++ b/docs/testing-server.md
@@ -50,7 +50,7 @@ let's grab all the relevant responses from yesterday's log:
     $ mapit-1> sudo awk '$9==404 {print "http://localhost:3108" $7}' /var/log/nginx/mapit-access.log | sort | uniq >mapit-404s
     $ mapit-1> sudo awk '$9==302 {print "http://localhost:3108" $7}' /var/log/nginx/mapit-access.log | sort | uniq >mapit-302s
 
-> In the commands above, for every line where the 9th field is ‘200’, print the string “http://localhost:3108” followed by the 7th field of that line, which is the postcode.
+> In the commands above, for every line where the 9th field is "200", print the string "http://localhost:3108" followed by the 7th field of that line, which is the postcode.
 
 Download the files via the jumpbox and store in your /Downloads folder, e.g.
 


### PR DESCRIPTION
It's causing build issues:

```
Error processing resource for index: apps/mapit/testing-server.html
bad URI(is not URI?): "http://localhost:3108%E2%80%9D"
 /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/uri/rfc3986_parser.rb:67:in `split'
 /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/uri/rfc3986_parser.rb:73:in `parse'
 /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/uri/common.rb:234:in `parse'
```