### PR TITLE
Rename default branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     stage('Checkout') {
       govuk.checkoutFromGitHubWithSSH(REPOSITORY)
       govuk.cleanupGit()
-      govuk.mergeMasterBranch()
+      govuk.mergeIntoBranch("main")
     }
 
     stage('Installing Packages') {
@@ -25,7 +25,7 @@ node {
       sh("venv/bin/python manage.py test --noinput mapit mapit_gb")
     }
 
-    if (env.BRANCH_NAME == 'master') {
+    if (env.BRANCH_NAME == 'main') {
       stage('Push release tag') {
         govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
       }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of [the MapIt repo](https://github.com/mysociety/mapit). MapIt is a Python/Django application (backed by PostgreSQL), that provides RESTful API for looking up postcodes, council boundaries, etc.
 
-**Avoid adding features, changing behaviours, or touching the code of MapIt itself**. The only [differences against the original repo](https://github.com/mysociety/mapit/compare/master...alphagov:master) should only be to help integrate it into the GOV.UK stack. So far this includes:
+**Avoid adding features, changing behaviours, or touching the code of MapIt itself**. The only [differences against the original repo](https://github.com/mysociety/mapit/compare/master...alphagov:main) should only be to help integrate it into the GOV.UK stack. So far this includes:
 
  - [Pinning to specific versions of Python dependencies](https://github.com/alphagov/mapit/pull/1), for reliability
  - [Adding a Procfile](https://github.com/alphagov/mapit/pull/2) and [unicornherder](https://github.com/alphagov/mapit/pull/12), to standardise deployment with other apps

--- a/docs/importing-data.md
+++ b/docs/importing-data.md
@@ -203,11 +203,11 @@ Note the last few lines where it says Buckinghamshire Council has no `ons` code 
 You may have output similar to this if these councils have had some updates, and
 you will have to make some additional updates in the code:
 
-  - Missing ONS/GSS codes are added in [mapit_UK_add_missing_codes.py](https://github.com/alphagov/mapit/blob/master/mapit_gb/management/commands/mapit_UK_add_missing_codes.py), see [this example](https://github.com/alphagov/mapit/commit/532f3e88ce0f5dea64b8f7eede6fb80605648e21)
-  - An ONS/GSS code might need to be updated, or council names updated/removed in [authorities.json](https://github.com/alphagov/mapit/blob/master/mapit_gb/data/authorities.json), see [this example](https://github.com/alphagov/mapit/commit/b4d96ffa6160cfa9a8414383b96e6f1a8fa01b71)
+  - Missing ONS/GSS codes are added in [mapit_UK_add_missing_codes.py](https://github.com/alphagov/mapit/blob/main/mapit_gb/management/commands/mapit_UK_add_missing_codes.py), see [this example](https://github.com/alphagov/mapit/commit/532f3e88ce0f5dea64b8f7eede6fb80605648e21)
+  - An ONS/GSS code might need to be updated, or council names updated/removed in [authorities.json](https://github.com/alphagov/mapit/blob/main/mapit_gb/data/authorities.json), see [this example](https://github.com/alphagov/mapit/commit/b4d96ffa6160cfa9a8414383b96e6f1a8fa01b71)
   - If there are merged/abolished authorities, to prevent it from being flagged in the
   next import's output (and potentially add to the confusion), you can add them to the
-  exception list in [mapit_UK_add_override_names_to_local_authorities.py](https://github.com/alphagov/mapit/blob/master/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py#L41) and [mapit_UK_add_slugs_to_local_authorities.py](https://github.com/alphagov/mapit/blob/master/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py#L36). You can also check if the authority
+  exception list in [mapit_UK_add_override_names_to_local_authorities.py](https://github.com/alphagov/mapit/blob/main/mapit_gb/management/commands/mapit_UK_add_override_names_to_local_authorities.py#L41) and [mapit_UK_add_slugs_to_local_authorities.py](https://github.com/alphagov/mapit/blob/main/mapit_gb/management/commands/mapit_UK_add_slugs_to_local_authorities.py#L36). You can also check if the authority
   is still active on [https://findthatpostcode.uk](https://findthatpostcode.uk/areas/E07000191.html)
 
 You will have to reset the db and re-import the data again.
@@ -361,6 +361,6 @@ might also be helpful. Also see [useful database queries](#useful-database-queri
 You can also search for the area by its ONS code on the ONS website e.g.
 http://statistics.data.gov.uk/atlas/resource?uri=http://statistics.data.gov.uk/id/statistical-geography/S17000011
 
-You can manually fix it by adding a correction in [mapit/management/find_parents.py](https://github.com/alphagov/mapit/blob/master/mapit/management/find_parents.py). See [this example](https://github.com/alphagov/mapit/commit/5b2ede155a157d7d69883a6a0197513bcbcca4bb)
+You can manually fix it by adding a correction in [mapit/management/find_parents.py](https://github.com/alphagov/mapit/blob/main/mapit/management/find_parents.py). See [this example](https://github.com/alphagov/mapit/commit/5b2ede155a157d7d69883a6a0197513bcbcca4bb)
 and [this example](https://github.com/alphagov/mapit/pull/70/files#diff-8e70109ed476fd7c998d2cd2a051297478b15d926e4c4d7645361197276292eeR203)
 for more information.

--- a/docs/testing-server.md
+++ b/docs/testing-server.md
@@ -93,7 +93,7 @@ environments.
 
 ## Running the test samples script
 
-For a more comprehensive test, you can use the [test-samples.sh](https://github.com/alphagov/mapit/blob/master/test-samples.sh)
+For a more comprehensive test, you can use the [test-samples.sh](https://github.com/alphagov/mapit/blob/main/test-samples.sh)
 script, which needs to be run before and after a database upgrade:
 
     $ your laptop> ssh mapit-1.production
@@ -120,7 +120,7 @@ change. If this happens, you might have to change some of our apps to use the
 new codes instead of the old ones.
 
 Our forked repo of MapIt contains a file [``mapit_gb/data/authorities.json``]
-(https://github.com/alphagov/mapit/blob/master/mapit_gb/data/authorities.json)
+(https://github.com/alphagov/mapit/blob/main/mapit_gb/data/authorities.json)
 which contains a list of Local Authorities, their slugs and their GSS codes.
 During the import (invoked by the `import-uk-onspd` script), the GSS codes are
 used to match to the areas in MapIt that represent LocalAuthorities and the


### PR DESCRIPTION
This is part of a wider move to rename default git branches to `main`. The jenkins file needed to be updated so that bulds would pass. Other changes in this commit are in place to ensure that links in docs and the README continue to work.