### PR TITLE
Add step to import missing links for new local authorities

### DIFF
--- a/docs/importing-data.md
+++ b/docs/importing-data.md
@@ -320,6 +320,12 @@ to Local Links Manager. This step can be skipped if there are no new authorities
    rake local_authority:update_homepage[govuk-slug,https://www.website.gov.uk/]
    ```
 
+1. Run [a Rake task](https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=local-links-manager&MACHINE_CLASS=backend&RAKE_TASK=import:missing_links) to add the service links for the new local authorities.
+
+   ```
+   rake import:missing_links
+   ```
+
 ## Troubleshooting
 
 ### Useful database queries


### PR DESCRIPTION
This step populates the services for the newly added local authorities.

[Trello card](https://trello.com/c/IwakiikF)